### PR TITLE
Added delete function, changed status response for roster requests

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,6 +26,16 @@ app.get('/', function(req, res) {
   return res.send('Madden Data')
 });
 
+//Clear previous export from firebase
+app.get('/delete', function(req, res) {
+  const db = admin.database();
+  const ref = db.ref();
+  const dataRef = ref.child(`data`);
+  dataRef.remove();
+  return res.send('Madden Data Cleared');
+});
+
+
 app.post('/:platform/:leagueId/leagueteams', (req, res) => {
   const db = admin.database();
   const ref = db.ref();
@@ -104,10 +114,11 @@ app.post('/:platform/:leagueId/freeagents/roster', (req, res) => {
   const {platform, leagueId} = req.params;
   const dataRef = ref.child(`data/${platform}/${leagueId}/freeagents`);
   const {body: {rosterInfoList}} = req;
+  res.sendStatus(202);
   dataRef.set({
     rosterInfoList
   });
-  res.sendStatus(200);
+  
 });
 
 app.post('/:platform/:leagueId/team/:teamId/roster', (req, res) => {
@@ -116,10 +127,11 @@ app.post('/:platform/:leagueId/team/:teamId/roster', (req, res) => {
   const {platform, leagueId, teamId} = req.params;
   const dataRef = ref.child(`data/${platform}/${leagueId}/team/${teamId}`);
   const {body: {rosterInfoList}} = req;
+  res.sendStatus(202);
   dataRef.set({
     rosterInfoList
   });
-  res.sendStatus(200);
+  
 });
 
 app.listen(app.get('port'), function() { console.log('Madden Companion Exporter is running on port', app.get('port')) });


### PR DESCRIPTION
Users can now visit to https://<appname>.herokuapp.com/delete with their browser to clear all previous exports from their firebase database.